### PR TITLE
common/{lz4_compression, zstd_compression}: Add missing header guards

### DIFF
--- a/src/common/lz4_compression.h
+++ b/src/common/lz4_compression.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <vector>
 
 #include "common/common_types.h"

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <vector>
 
 #include "common/common_types.h"


### PR DESCRIPTION
These two files were missing the #pragma once directive.